### PR TITLE
use urls instead of path strings, do not rely on FileManager.currentPath

### DIFF
--- a/Cute/Impl/AnyJobPersister.swift
+++ b/Cute/Impl/AnyJobPersister.swift
@@ -25,7 +25,7 @@ public class AnyJobPersister<HandlingJob: QueueJob>: JobPersister {
     private let _persist: (_ jobs: [HandlingJob]) throws -> Void
     private let _delete: (_ job: HandlingJob) throws -> Void
     private let _load: () throws -> [HandlingJob]
-    private let _clear: (_ completion: ((Error?) -> Void)?) -> Void
+    private let _clear: (_ completion: ((Error?) -> Void)?) throws -> Void
     
     /// Creates a new wrapper for the given `JobPersister`
     public init<P: JobPersister>(_ persister: P) where P.JobType == HandlingJob {
@@ -62,7 +62,7 @@ public class AnyJobPersister<HandlingJob: QueueJob>: JobPersister {
     /// Deletes all jobs from the persisted location using the internal `JobPersister`
     ///
     /// - Parameter completion: An optional callback to be called after the clearing has completed.
-    public func clear(completion: ((Error?) -> Void)? = nil) {
-        _clear(completion)
+    public func clear(completion: ((Error?) -> Void)? = nil) throws {
+        try _clear(completion)
     }
 }

--- a/Cute/Impl/FileBasedPersister.swift
+++ b/Cute/Impl/FileBasedPersister.swift
@@ -30,7 +30,7 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
         let fm = fileManager
 
         guard let dir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            fatalError("Could not get applicatinSupportDirectory for current user.")
+            fatalError("Could not get applicationSupportDirectory for current user.")
         }
 
         let path: URL = dir.appendingPathComponent("Cute/Queues/\(queueName)", isDirectory: true)
@@ -42,7 +42,7 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
             fatalError("Unable to create directory: \(error)")
         }
 
-        print("QueueJobs will be persisted at \(path.absoluteString)")
+        print("QueueJobs will be persisted at \(path.path)")
         return path
     }()
 

--- a/Cute/Impl/FileBasedPersister.swift
+++ b/Cute/Impl/FileBasedPersister.swift
@@ -90,15 +90,7 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
     public func load() throws -> [HandlingJob] {
         let decoder = JSONDecoder()
         let jobs: [HandlingJob] = try fileManager.contentsOfDirectory(at: persistenceLocation, includingPropertiesForKeys: [], options: .skipsSubdirectoryDescendants).compactMap { path in
-
-            let data: Data
-            do {
-                data = try Data(contentsOf: path)
-            } catch {
-                print("Warning: Unable to parse: \(path.path)")
-                return nil
-            }
-
+            let data = try Data(contentsOf: path)
             return try decoder.decode(Job.self, from: data)
         }
         
@@ -108,15 +100,9 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
     /// Clears all persisted jobs from disk
     ///
     /// - Parameter completion: The block to call after the attempt to clear all jobs is complete.
-    public func clear(completion: ((Error?) -> Void)?) {
+    public func clear(completion: ((Error?) -> Void)?) throws {
 
-        let files: [URL]
-        do {
-            files = try fileManager.contentsOfDirectory(at: persistenceLocation, includingPropertiesForKeys: [], options: .skipsSubdirectoryDescendants)
-        } catch {
-            // a directory that cannot be read is almost the same as an empty directory, right? I think it's safe to ignore
-            files = []
-        }
+        let files = try fileManager.contentsOfDirectory(at: persistenceLocation, includingPropertiesForKeys: [], options: .skipsSubdirectoryDescendants)
 
         files.forEach {
             do {

--- a/Cute/Impl/FileBasedPersister.swift
+++ b/Cute/Impl/FileBasedPersister.swift
@@ -13,8 +13,8 @@ import Foundation
 public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
     typealias Job = HandlingJob
     
-    private var queueName: String
-    
+    private let queueName: String
+
     /// Creates a name for the given job, based on the job's `id` and `createdDate`.
     ///
     /// - Parameter job: The job from which a filename will be generated
@@ -26,29 +26,29 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
     }
     
     /// Provides the path to where this Persister is performing its IO.
-    public var persistenceLocation: String {
-        return fileManager.currentDirectoryPath
-    }
-    
-    /// The file manager this Persister will use for all Job IO.
-    lazy private var fileManager: FileManager = {
-        let fm = FileManager()
-        
+    lazy public var persistenceLocation: URL = {
+        let fm = fileManager
+
         guard let dir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             fatalError("Could not get applicatinSupportDirectory for current user.")
         }
-        
-        let path = dir.appendingPathComponent("Cute/Queues/\(queueName)", isDirectory: true)
-        
-        if !fm.fileExists(atPath: path.absoluteString) {
-            try! fm.createDirectory(at: path, withIntermediateDirectories: true)
+
+        let path: URL = dir.appendingPathComponent("Cute/Queues/\(queueName)", isDirectory: true)
+
+        // note: Apple recommends not checking for the existence of the directory and just creating it instead
+        do {
+            try fm.createDirectory(at: path, withIntermediateDirectories: true)
+        } catch let error {
+            fatalError("Unable to create directory: \(error)")
         }
-        
-        fm.changeCurrentDirectoryPath(path.path)
-        print("QueueJobs will be persisted at \(fm.currentDirectoryPath)")
-        return fm
+
+        print("QueueJobs will be persisted at \(path.absoluteString)")
+        return path
     }()
-    
+
+    /// The file manager this Persister will use for all Job IO.
+    private var fileManager = FileManager()
+
     /// Initializes this JobPersister
     ///
     /// - Parameters:
@@ -66,7 +66,10 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
         let encoder = JSONEncoder()
         
         for j in jobs {
-            fileManager.createFile(atPath: makeFileName(forJob: j), contents: try encoder.encode(j))
+            var path = persistenceLocation
+            path.appendPathComponent(makeFileName(forJob: j), isDirectory: false)
+            let data = try encoder.encode(j)
+            try data.write(to: path)
         }
     }
     
@@ -75,8 +78,9 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
     /// - Parameter job: The job whose persisted file is to be deleted
     /// - Throws: An error if the job's persiste file fails to delete.
     public func delete(_ job: HandlingJob) throws {
-        let file = makeFileName(forJob: job)
-        if fileManager.fileExists(atPath: file) { try fileManager.removeItem(atPath: file) }
+        var path = persistenceLocation
+        path.appendPathComponent(makeFileName(forJob: job))
+        try fileManager.removeItem(at: path)
     }
     
     /// Loads all jobs from file in the correct order
@@ -85,13 +89,17 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
     /// - Throws: An error if any of the jobs failed to load from disk.
     public func load() throws -> [HandlingJob] {
         let decoder = JSONDecoder()
-        let jobs: [HandlingJob] = try fileManager.contentsOfDirectory(atPath: ".").sorted().compactMap { path in
-            if let data = fileManager.contents(atPath: path) {
-                print("loading job at \(path)")
-                return try decoder.decode(Job.self, from: data)
+        let jobs: [HandlingJob] = try fileManager.contentsOfDirectory(at: persistenceLocation, includingPropertiesForKeys: [], options: .skipsSubdirectoryDescendants).compactMap { path in
+
+            let data: Data
+            do {
+                data = try Data(contentsOf: path)
+            } catch {
+                print("Warning: Unable to parse: \(path.path)")
+                return nil
             }
-            
-            return nil
+
+            return try decoder.decode(Job.self, from: data)
         }
         
         return jobs.sorted { left, right in left.createdDate < right.createdDate }
@@ -101,15 +109,23 @@ public class FileBasedPersister<HandlingJob: QueueJob>: JobPersister {
     ///
     /// - Parameter completion: The block to call after the attempt to clear all jobs is complete.
     public func clear(completion: ((Error?) -> Void)?) {
+
+        let files: [URL]
         do {
-            let path = fileManager.currentDirectoryPath
-            try fileManager.removeItem(atPath: path)
-            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
-            fileManager.changeCurrentDirectoryPath(path)
-        } catch let error {
-            completion?(error)
+            files = try fileManager.contentsOfDirectory(at: persistenceLocation, includingPropertiesForKeys: [], options: .skipsSubdirectoryDescendants)
+        } catch {
+            // a directory that cannot be read is almost the same as an empty directory, right? I think it's safe to ignore
+            files = []
         }
-        
+
+        files.forEach {
+            do {
+                try fileManager.removeItem(at: $0)
+            } catch let error {
+                completion?(error)
+            }
+        }
+
         completion?(nil)
     }
 }

--- a/Cute/Impl/JobQueue.swift
+++ b/Cute/Impl/JobQueue.swift
@@ -229,10 +229,15 @@ extension JobQueue {
         queueDispatch.async(flags: .barrier) { [weak self] in
             let jobs = self?.jobs
             self?.jobs.removeAll()
-            self?.persister?.clear()
+            do {
+                try self?.persister?.clear()
+            } catch let error {
+                // note: unable to throw from within a dispatched block, so this will have to do
+                print("Error: Unable to clear persistent files: \(error)")
+            }
             
-            if jobs != nil {
-                self?.notifyObserversThatQueue(.removed, jobs: jobs!)
+            if let jobs = jobs {
+                self?.notifyObserversThatQueue(.removed, jobs: jobs)
             }
         }
     }

--- a/Cute/Interface/JobPersister.swift
+++ b/Cute/Interface/JobPersister.swift
@@ -36,5 +36,5 @@ public protocol JobPersister: class {
     /// Deletes all jobs from the persisted location.
     ///
     /// - Parameter completion: An optional callback to be called after the clearing has completed.
-    func clear(completion: ((Error?) -> Void)?) -> Void
+    func clear(completion: ((Error?) -> Void)?) throws -> Void
 }

--- a/CuteTests/Impl/FileBasedPersisterTests.swift
+++ b/CuteTests/Impl/FileBasedPersisterTests.swift
@@ -29,19 +29,19 @@ class FileBasedPersisterTests: QuickSpec {
             }
             
             it("persists at the expected location") {
-                expect(persister.persistenceLocation.contains("Cute/Queues/MyTestQueue")) == true
+                expect(persister.persistenceLocation.path.contains("Cute/Queues/MyTestQueue")) == true
             }
             
             it("can persist jobs") {
                 try! persister.persist([TestJob()])
-                expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation).count) == 1
+                expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation.path).count) == 1
             }
             
             it("can remove a job") {
                 let job = TestJob()
                 try! persister.persist([job])
                 try! persister.delete(job)
-                expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation).count) == 0
+                expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation.path).count) == 0
             }
             
             it("can load jobs") {
@@ -67,10 +67,10 @@ class FileBasedPersisterTests: QuickSpec {
                 }.toNot(throwError())
                 
                 // sanity check
-                expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation).count) > 0
+                expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation.path).count) > 0
                 
                 waitUntil { done in persister.clear { _ in done() } }
-                expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation).count) == 0
+                expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation.path).count) == 0
             }
             
         }

--- a/CuteTests/Impl/FileBasedPersisterTests.swift
+++ b/CuteTests/Impl/FileBasedPersisterTests.swift
@@ -21,7 +21,7 @@ class FileBasedPersisterTests: QuickSpec {
             
             afterEach {
                 waitUntil(timeout: 5) { done in
-                    persister.clear { error in
+                    try? persister.clear { error in
                         if let err = error { print(err) }
                         done()
                     }
@@ -69,7 +69,7 @@ class FileBasedPersisterTests: QuickSpec {
                 // sanity check
                 expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation.path).count) > 0
                 
-                waitUntil { done in persister.clear { _ in done() } }
+                waitUntil { done in try? persister.clear { _ in done() } }
                 expect(try? FileManager.default.contentsOfDirectory(atPath: persister.persistenceLocation.path).count) == 0
             }
             

--- a/CuteTests/Impl/JobQueueTests.swift
+++ b/CuteTests/Impl/JobQueueTests.swift
@@ -234,6 +234,7 @@ class JobQueueTests: QuickSpec {
                     token = q.observe { observationBlock($0, $1, $2) }
                     q.add(jobs)
                     
+                    expect(token).toEventuallyNot(beNil())
                     expect(observation).toEventuallyNot(beNil())
                     expect(observation?.queue).toEventuallyNot(beNil())
                     expect(observation?.jobs).toEventually(equal(jobs))

--- a/CuteTests/Impl/RetryStrategies/MaxRetryStrategySpec.swift
+++ b/CuteTests/Impl/RetryStrategies/MaxRetryStrategySpec.swift
@@ -34,6 +34,8 @@ class MaxRetryStrategySpec: QuickSpec {
                         retryMap[job.id] = (retryMap[job.id] ?? 0) + 1
                     }
                 }
+
+                expect(token).toNot(beNil()) // just to prevent a warning about token not being read
                 
                 let jobs = (0..<3).map { _ in TestJob() }
                 fixture.queue.add(jobs)


### PR DESCRIPTION
This addresses #1. The main change is not rely on the FileManager's "current directory", and instead use absolute paths. I also updated the code to use the FileManager's more modern URL methods (instead of String paths). All tests pass. Comments appreciated!